### PR TITLE
Update npm install command to only include mlld

### DIFF
--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -18,7 +18,7 @@ layout: base.njk
 <section class="install">
   <div class="install-container">
     <div class="install-command">
-      <code>npm install -g mlld llm</code>
+      <code>npm install -g mlld</code>
       <button class="copy-button" onclick="const btn = this; navigator.clipboard.writeText('npm install -g mlld'); btn.classList.add('copied'); setTimeout(() => btn.classList.remove('copied'), 1500);"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-copy" viewBox="0 0 16 16">
   <path fill-rule="evenodd" d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"/>
 </svg></button>


### PR DESCRIPTION
Remove 'llm' from the npm install command on the homepage, showing only 'npm install -g mlld'