### PR TITLE
fix: add ESLint exemptions for legitimate string operations and CI checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Build grammar (required for linting)
+      run: npm run build:grammar
+    
+    - name: Run ESLint
+      run: npm run lint
+      continue-on-error: false # Fail the build on any ESLint errors
+    
+    - name: Check for AST violations
+      run: |
+        echo "Checking for AST-specific rule violations..."
+        npm run lint 2>&1 | grep -E "(no-raw-field-access|no-ast-string-manipulation|require-ast-type-guards)" || echo "No AST violations found ✓"
+      if: always() # Run even if previous step failed

--- a/core/registry/StatsCollector.ts
+++ b/core/registry/StatsCollector.ts
@@ -1,3 +1,8 @@
+// String operations are legitimate in this file for JSONL parsing
+// This file reads and writes JSON Lines format (.jsonl) for usage statistics,
+// which requires line-by-line string splitting to parse multiple JSON objects
+// from a single file. This is a storage format concern, not AST manipulation.
+
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/core/utils/sourceContextExtractor.ts
+++ b/core/utils/sourceContextExtractor.ts
@@ -1,3 +1,8 @@
+// String operations are legitimate in this file for error message formatting
+// This file extracts source code context for error messages, requiring line-by-line
+// string splitting to show code snippets with line numbers and error indicators.
+// This is purely for human-readable output formatting, not AST manipulation.
+
 import { IFileSystemService } from '@services/fs/IFileSystemService';
 import { FormattedLocation } from './locationFormatter';
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -136,6 +136,20 @@ export default tseslint.config(
     }
   },
   
+  // Files with legitimate string operations (not for AST manipulation)
+  {
+    files: [
+      'core/registry/StatsCollector.ts',         // JSONL parsing for usage statistics
+      'core/utils/sourceContextExtractor.ts',    // Error message formatting
+      'interpreter/core/interpolation-context.ts', // Security escaping for execution contexts
+      'interpreter/utils/frontmatter-parser.ts'   // YAML frontmatter preprocessing
+    ],
+    rules: {
+      // These files legitimately manipulate strings for non-AST purposes
+      'mlld/no-ast-string-manipulation': 'off'
+    }
+  },
+  
   // Ignore patterns
   {
     ignores: [

--- a/interpreter/core/interpolation-context.ts
+++ b/interpreter/core/interpolation-context.ts
@@ -1,3 +1,8 @@
+// String operations are legitimate in this file for security escaping
+// This file implements security-critical escaping strategies for different execution
+// contexts (shell, URL, etc.). String manipulation here prevents injection attacks
+// by properly escaping special characters based on the target context.
+
 /**
  * Interpolation Context System
  * 

--- a/interpreter/utils/frontmatter-parser.ts
+++ b/interpreter/utils/frontmatter-parser.ts
@@ -1,3 +1,8 @@
+// String operations are legitimate in this file for YAML frontmatter preprocessing
+// This file preprocesses YAML frontmatter before parsing to handle edge cases like
+// unquoted @ symbols in package names. This preprocessing is necessary because YAML
+// parsers interpret @ as special characters, requiring pre-parse string manipulation.
+
 import * as yaml from 'js-yaml';
 import { MlldParseError } from '@core/errors';
 


### PR DESCRIPTION
## Summary
This PR addresses two related issues to improve our ESLint setup:

1. **Fixes #179**: Adds ESLint exemptions for files with legitimate string operations
2. **Fixes #180**: Adds GitHub Actions workflow for ESLint CI checks

## Changes

### ESLint Configuration Updates
- Added exemptions for 4 utility files that legitimately manipulate strings for non-AST purposes:
  - `core/registry/StatsCollector.ts` - JSONL parsing for usage statistics
  - `core/utils/sourceContextExtractor.ts` - Error message formatting with line numbers
  - `interpreter/core/interpolation-context.ts` - Security-critical escaping for execution contexts
  - `interpreter/utils/frontmatter-parser.ts` - YAML frontmatter preprocessing

### Documentation
- Added explanatory comments to the top of each exempted file explaining why string operations are legitimate

### CI/CD Enhancement
- Created `.github/workflows/lint.yml` workflow that:
  - Runs on all PRs to main branch and pushes to main
  - Builds grammar before linting (required dependency)
  - Fails the build on any ESLint errors
  - Provides specific feedback for AST-related violations

## Testing
- Verified ESLint configuration changes work correctly:
  - `npm run lint:ast` shows 24 violations, none from exempted files
  - Exempted files no longer trigger `no-ast-string-manipulation` errors
- GitHub Actions workflow syntax is valid and ready for use

## Impact
- Prevents new ESLint violations from being merged to main
- Maintains code quality standards automatically
- Makes our custom AST linting rules actually effective in practice