### PR TITLE
fix: ESLint Phase 2 - CLI Console Output

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -136,6 +136,17 @@ export default tseslint.config(
     }
   },
   
+  // CLI commands need console output for user interaction
+  {
+    files: [
+      'cli/commands/**/*.ts',
+      'cli/utils/**/*.ts'
+    ],
+    rules: {
+      'no-console': 'off', // CLI commands need console output
+    }
+  },
+  
   // Files with legitimate string operations (not for AST manipulation)
   {
     files: [


### PR DESCRIPTION
Closes #187

## Changes
- Added ESLint override in eslint.config.mjs for CLI directory
- Allows console.log specifically for cli/commands/**/*.ts and cli/utils/**/*.ts
- CLI tools fundamentally need console output for user interaction

## Results
- 149 no-console warnings fixed (from 478 to 329)
- All CLI commands still output correctly
- All tests passing
- Build successful