### PR TITLE
fix: ESLint Phase 3 - TypeScript Type Safety (API & Config)

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -41,10 +41,10 @@ export async function processMlld(content: string, options?: ProcessOptions): Pr
   // Create default services if not provided
   const fileSystem = options?.fileSystem || new NodeFileSystem();
   const pathService = options?.pathService || new PathService();
-  const basePath = options?.basePath || process.cwd();
+  const basePath: string = options?.basePath || process.cwd();
   
   // Call the interpreter
-  const result = await interpret(content, {
+  const result: string = await interpret(content, {
     basePath,
     format: options?.format || 'markdown',
     fileSystem,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from 'tsup';
+import type { Options } from 'tsup';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-const packageJson = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8'));
+interface PackageJson {
+  version: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+const packageJson = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8')) as PackageJson;
 
 // Define common external dependencies to ensure consistency across builds
 const externalDependencies = [
@@ -31,7 +38,9 @@ const externalDependencies = [
 ];
 
 // Define common esbuild options
-const getEsbuildOptions = (format: string) => (options: any) => {
+type EsbuildOptions = NonNullable<Options['esbuildOptions']> extends (options: infer T, context: unknown) => unknown ? T : never;
+
+const getEsbuildOptions = (format: string) => (options: EsbuildOptions) => {
   options.alias = {
     '@core': './core',
     '@services': './services',
@@ -45,7 +54,7 @@ const getEsbuildOptions = (format: string) => (options: any) => {
   };
   
   options.define = {
-    ...options.define,
+    ...(options.define || {}),
     '__VERSION__': `"${packageJson.version}"`
   };
   


### PR DESCRIPTION
Closes #188

## Changes
- Added explicit type annotations to api/index.ts to fix unsafe assignment errors
- Fixed JSON.parse unsafe any assignment in tsup.config.ts with typed interface
- Replaced any types in esbuild options with proper type inference
- Fixed unsafe spread operator usage with proper null checking

## Results
- 5 TypeScript errors fixed (3 in api/index.ts, 2+ in tsup.config.ts)
- All tests passing
- Build successful