### PR TITLE
fix: ESLint Phase 5 - Test File Cleanup

### DIFF
--- a/cli/commands/init.test.ts
+++ b/cli/commands/init.test.ts
@@ -46,7 +46,7 @@ describe('initCommand', () => {
         await fs.access(path.join(cwd, 'mlld.json'));
         console.error('Error: mlld.json already exists in this directory.');
         process.exit(1);
-      } catch (e) {
+      } catch (_e) {
         // File doesn't exist, continue
       }
       

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -147,6 +147,17 @@ export default tseslint.config(
     }
   },
   
+  // Test mock utilities need to access real console
+  {
+    files: [
+      'tests/utils/cli/mockConsole.ts',
+      'tests/utils/cli/mockProcessExit.ts'
+    ],
+    rules: {
+      'no-console': 'off', // Mock utilities need console for debugging
+    }
+  },
+  
   // Files with legitimate string operations (not for AST manipulation)
   {
     files: [

--- a/tests/utils/FileSystemAdapter.ts
+++ b/tests/utils/FileSystemAdapter.ts
@@ -20,7 +20,7 @@ export class FileSystemAdapter {
         return Buffer.from(content, 'utf8');
       },
 
-      writeFile: async (filePath: string, content: string | Buffer, encoding?: string): Promise<void> => {
+      writeFile: async (filePath: string, content: string | Buffer, _encoding?: string): Promise<void> => {
         const data = Buffer.isBuffer(content) ? content.toString('utf8') : content;
         await this.fileSystem.writeFile(filePath, data);
       },

--- a/tests/utils/MemoryFileSystem.ts
+++ b/tests/utils/MemoryFileSystem.ts
@@ -120,7 +120,7 @@ export class MemoryFileSystem implements IFileSystemService {
   }
   
   // Add execute method for command execution (needed by Environment)
-  async execute(command: string, options?: any): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  async execute(command: string, _options?: any): Promise<{ stdout: string; stderr: string; exitCode: number }> {
     // Mock implementation - can be customized per test
     return {
       stdout: `Mock output for: ${command}`,


### PR DESCRIPTION
Closes #190

## Changes
- Added test file exemptions to eslint.config.mjs for mock utilities
- Fixed unused variables by prefixing with _ (catch clauses and unused parameters)
- Allowed console.log in test mock utilities (mockConsole.ts, mockProcessExit.ts)
- Cleaned up unused parameters in FileSystemAdapter and MemoryFileSystem

## Results
- No warnings in test utility files
- Unused variables properly handled with _ prefix
- Test mocks work correctly and all tests pass
- Build successful

## Files Modified
- \ - Exempted from no-console rule
- \ - Exempted from no-console rule  
- \ - Fixed unused catch variable
- \ - Fixed unused encoding parameter
- \ - Fixed unused options parameter