### PR TITLE
ci: run tests on push and pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,43 +1,39 @@
-name: PR Tests
+name: Tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        node-version: [18, 20]
-    
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Use Node.js ${{ matrix.node-version }}
+
+    - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    
+        node-version: 20
+        cache: npm
+
     - name: Install dependencies
       run: npm ci
-    
+
     - name: Build grammar (required before tests)
       run: npm run build
-    
+
     - name: Run tests
       run: npm test
       # Note: Token edge case tests are excluded from main test suite
       # Run locally with: npm run test:tokens
-    
+
     - name: Run test coverage
       run: npm run test:coverage
-      if: matrix.node-version == '20'
-    
+
     - name: Upload coverage reports
       uses: codecov/codecov-action@v4
-      if: matrix.node-version == '20'
       with:
         fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- run test workflow on pushes to main and pull requests
- use Node.js 20 for tests, build, and coverage

## Testing
- `npx vitest run core/config/config.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acc51442688331bcf8d0e7ada9f77a